### PR TITLE
add: thirdweb to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Awesome Ethereum & Dapps Resources
 - [Etherflow: A FOSS tool for Ethereum developers to test their node, and compose & debug RPC calls from the browser.](https://etherflow.quiknode.io/)
 - [ZMOK: Publicly accessible Web3 JSON/RPC provider URL's.](https://zmok.io/)
 - [Covalent: A unified API bringing visibility to billions of blockchain data points.](https://zmok.io/)
+- [thirdweb: Build Web3 apps easily, providing developers with easy-to-use tools and open-source SDKs to build, launch, and manage Web3 projects.](https://thirdweb.com/)
 
 #### Where do I start?
 - [Download the wallet and build your own cryptocurrency](https://blog.ethereum.org/2015/12/03/how-to-build-your-own-cryptocurrency/)


### PR DESCRIPTION
I add [thirdweb](https://thirdweb.com) to the developer tools section.
thirdweb supports ETH chain so it is good to add this here as a developer tool.