### PR TITLE
add 3xpl.com and blockchair.com to block explorers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ decided that it has value.
 - [MyEtherWallet: Browser Based Wallet](https://www.myetherwallet.com/)
 - [MyCrypto: Browser Based Wallet](https://mycrypto.com/)
 - [DeBank: Browser Based DeFi Wallet and DeFi analytics](https://debank.com/)
+- [3xpl: Fastest ad-free universal block explorer](https://3xpl.com)
+- [Blockchair: Universal blockchain explorer and search engine](https://blockchair.com)
 
 #### Developer Tools
 - [Remix: IDE for writing Solidity Smart Contracts](http://remix.ethereum.org/)


### PR DESCRIPTION
This PR adds 3xpl.com and blockchair.com to block explorer list.

Quick overview: [Blockchair](https://blockchair.com) is known to be one of the best blockchain explorers. On the other hand, 3xpl is a new product from Blockchair that is a fast and ad-free alternative blockchain explorer.

Reference:
https://shardeum.org/blog/best-blockchain-explorers/#:~:text=Blockchair%20Explorer%20is%20a%20popular%20blockchain%20explorer
https://sensoriumxr.com/articles/best-blockchain-explorers#:~:text=Blockchair.com%20is%20the%20best%20blockchain

I hope this is something the team is interested in.

