### PR TITLE
Add dRPC Agent Skills to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ decided that it has value.
 - [Dynamic: A powerful web3 auth developer platform.](https://www.dynamic.xyz)
 - [web3-ethereum-defi: Data research and trading library to work with DeFi for Python](https://web3-ethereum-defi.readthedocs.io/)
 - [Cannon: Like Terraform, Docker and NPM for Ethereum](https://usecannon.com)
+- [dRPC Agent Skills: Call Ethereum JSON-RPC methods (eth_call, eth_getBalance, eth_estimateGas, eth_getLogs, etc.) from AI coding agents via DRPC's gateway.](https://github.com/drpcorg/drpc-agent-skills)
 
 
 


### PR DESCRIPTION
## Summary

Adds [dRPC Agent Skills](https://github.com/drpcorg/drpc-agent-skills) to the **Developer Tools** section.

dRPC Agent Skills lets AI coding agents call Ethereum JSON-RPC methods (`eth_call`, `eth_getBalance`, `eth_estimateGas`, `eth_getLogs`, etc.) through DRPC's gateway, making on-chain data accessible directly from agent workflows.