### PR TITLE
Add zig-evm to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ decided that it has value.
 - [Dynamic: A powerful web3 auth developer platform.](https://www.dynamic.xyz)
 - [web3-ethereum-defi: Data research and trading library to work with DeFi for Python](https://web3-ethereum-defi.readthedocs.io/)
 - [Cannon: Like Terraform, Docker and NPM for Ethereum](https://usecannon.com)
+- [zig-evm: High-performance, embeddable EVM in Zig with wave-based parallel transaction execution, 96+ opcodes, and precompiles (blake2f, BN254, ripemd160). MIT-licensed; targets L2/Rollup execution with C/Python/Rust/JS FFI bindings.](https://github.com/cryptuon/zig-evm)
 
 
 


### PR DESCRIPTION
Add [zig-evm](https://github.com/cryptuon/zig-evm) — a high-performance, embeddable EVM written in Zig with wave-based parallel transaction execution, 96+ opcodes, and precompiles (blake2f, BN254, ripemd160). MIT-licensed; targets L2/Rollup execution with C/Python/Rust/JS FFI bindings. Placed under Developer Tools as a VM/runtime for Ethereum development.