### PR TITLE
Add OpenChainBench to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ decided that it has value.
 - [Dynamic: A powerful web3 auth developer platform.](https://www.dynamic.xyz)
 - [web3-ethereum-defi: Data research and trading library to work with DeFi for Python](https://web3-ethereum-defi.readthedocs.io/)
 - [Cannon: Like Terraform, Docker and NPM for Ethereum](https://usecannon.com)
+- [OpenChainBench: Independent open-source benchmarks for Ethereum and L2 RPC providers, gas oracles, and L2 finality across 22 chains. CC BY 4.0 data.](https://openchainbench.com)
 
 
 


### PR DESCRIPTION
## Summary

Adds [OpenChainBench](https://openchainbench.com) to the **Developer Tools** section.

## Why it fits

OpenChainBench is an independent open-source benchmarking site publishing continuous measurements of Ethereum and L2 RPC providers, gas oracles, and archive coverage across 22 chains. Ethereum developers picking an RPC endpoint currently rely on provider self-reporting; OCB provides the neutral third party datapoint (latency, uptime, error classification) needed for informed selection.

Data ships under CC BY 4.0, harnesses are open-source Go/Rust on GitHub, and the site has no affiliation with any chain foundation or provider.

## Change

One line added to Developer Tools alphabetically. No other changes.