### PR TITLE
Add Kerne Verify Any Stablecoin to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ decided that it has value.
 - [3xpl: Fastest ad-free universal block explorer](https://3xpl.com)
 - [Blockchair: Universal blockchain explorer and search engine](https://blockchair.com)
 - [Address Checker: Identify malicious addresses and spam tokens](https://bac.nader.io)
+- [Kerne Verify Any Stablecoin: live on-chain supply read for any Base or Ethereum stablecoin](https://kerne.fi/verify-anything)
 
 #### Ethereum Clients
 - [py-ethclient](https://github.com/tokamak-network/py-ethclient) - Python Ethereum execution client built from scratch — EVM (140+ opcodes), RLPx, eth/68, snap/1, full & snap sync, Engine API, and JSON-RPC.


### PR DESCRIPTION
Refiling #84, which you closed on 26 August because `https://kerne.fi/verify-anything` "returned no readable content when I checked", with the note "feel free to reopen or file a new PR and I'll take another look".

I tried the reopen first and could not: I force-pushed that branch before trying, which permanently blocks reopening, and putting the original commit back did not undo it. The branch is restored, so #84 still shows exactly the diff you closed. Hence a new PR.

**On what you saw: I could not reproduce it, and I am not going to hand you a cause I cannot stand behind.** I did find that some hosts get a bare HTTP 403 from kerne.fi, but the same hosts also get 403 from `vercel.com` and `openai.com` while `example.com` returns 200, so that is IP reputation on the client side rather than something specific to us, and it does not describe a normal browser. I mention it only because it is the closest thing I found and I would rather show you the loose end than invent a tidy story.

One thing that is genuinely ours: the site runs a repeating announcement banner above the header, so a plain text extraction of the page opens with about 540 characters of banner and nav before it reaches the page's own heading. If your check summarised the front of the extracted text, that would read as nothing about a tool.

**What the URL returns, 31 August.** `curl -sI https://kerne.fi/verify-anything` returns `HTTP/1.1 200 OK`, `Content-Type: text/html; charset=utf-8`. The body is 133,411 bytes and byte identical across curl, a Chrome user agent, a Googlebot user agent and an empty user agent. The route is a static prerender (`x-nextjs-prerender: 1`), so the text is in the HTML with JavaScript off.

* `<title>` Verify any stablecoin's reserves yourself | Kerne
* `<h1>` Verify any stablecoin's reserves yourself.
* `<h2>` Where verification ends and trust begins / Or verify a specific stablecoin / What this tool does and does not prove / Common questions

**Without touching our servers at all.** The Internet Archive holds full 200 captures on both sides of the day you checked:

* https://web.archive.org/web/20260710163401/https://kerne.fi/verify-anything
* https://web.archive.org/web/20260829003733/https://kerne.fi/verify-anything

**What changed in this diff.** The entry is 128 characters instead of the 211 in #84, so it sits closer to the rest of the Tools section. Still one line, one file, nothing else touched, and the blank line before `#### Ethereum Clients` is untouched.

**On track record**, which I think is the fairer of the two bars: the tool is a web page, but the work behind it is public and MIT licensed.

* [kerne-protocol/realized-apy](https://github.com/kerne-protocol/realized-apy). Zero dependencies, no API key. One command re-derives 21 published stablecoin yield figures from public archive RPC in about 25 seconds and exits non-zero if any row fails to reproduce.
* [kerne-protocol/signed-por](https://github.com/kerne-protocol/signed-por). A vendor neutral verifier for signed proof of reserve attestations, with two real production fixtures captured five schema revisions apart.
* [kerne-protocol/contracts-public](https://github.com/kerne-protocol/contracts-public). Deployment registry plus a walkthrough for verifying the live contracts through a public RPC we do not operate.

Honest counterweight, since you have been asking people for one: those repositories have almost no stars, and kerne.fi was registered in March 2026. If your read is that this is still too new for the list, that is a fair call and I will not argue it.

Disclosure: I work on Kerne, so this is my own project.
